### PR TITLE
Watch address to prompt refresh on change

### DIFF
--- a/components/Set/OptIn.vue
+++ b/components/Set/OptIn.vue
@@ -44,8 +44,16 @@ const onComplete = () => {
   revealed.value = true
 }
 
-const url = `${config.public.opepenApi}/accounts/${address.value}/sets/${props.set.id}`
-const { data: subscription, refresh } = await useLazyFetch(url)
+const { data: subscription, refresh } = await useLazyAsyncData(
+  'set',
+  () =>
+    $fetch(
+      `${config.public.opepenApi}/accounts/${address.value}/sets/${props.set.id}`
+    ),
+  {
+    watch: [address],
+  }
+);
 
 const optInOpen = ref(false)
 watch(optInOpen, () => {


### PR DESCRIPTION
Quick little PR to trigger a refresh on the `accounts/<address>/sets/<set_id>` endpoint when the connected account (notably the `address` property) changes.

I'm not too familiar with Vue but appears that watching the address in the `useLazyFetch` hook can result in the request running while `address` is still undefined.